### PR TITLE
Update local replay directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The player allows users to pick one or more ARC/WARC from their local machine an
 
    You can use https://webrecorder.io to record pages as you browse and then download the WARC file.
 
-4. A browser will open to [http://localhost:8090/replay/](http://localhost:8090/replay/) listing all the pages in the archive.
+4. A browser will open to [http://localhost:8090/](http://localhost:8090/) listing all the pages in the archive.
 
 5. Click on any page listed to view the replay. Or, enter a url to search the full archive.
 


### PR DESCRIPTION
Not sure how long this has been the case, but as of 1.4.7 the archive replays from http://localhost:8090/ not http://localhost:8090/replay/